### PR TITLE
Changes to use Ironic Stein

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -24,7 +24,7 @@ fi
 if [ -e $FFILENAME.headers ] ; then
     ETAG=$(awk '/ETag:/ {print $2}' $FFILENAME.headers | tr -d "\r")
     cd $TMPDIR
-    curl --dump-header $FFILENAME.headers -O https://images.rdoproject.org/master/rdo_trunk/$SNAP/$FFILENAME --header "If-None-Match: $ETAG"
+    curl --dump-header $FFILENAME.headers -O https://images.rdoproject.org/stein/rdo_trunk/$SNAP/$FFILENAME --header "If-None-Match: $ETAG"
     # curl didn't download anything because we have the ETag already
     # but we don't have it in the images directory
     # Its in the cache, go get it
@@ -35,7 +35,7 @@ if [ -e $FFILENAME.headers ] ; then
     fi
 else
     cd $TMPDIR
-    curl --dump-header $FFILENAME.headers -O https://images.rdoproject.org/master/rdo_trunk/$SNAP/$FFILENAME
+    curl --dump-header $FFILENAME.headers -O https://images.rdoproject.org/stein/rdo_trunk/$SNAP/$FFILENAME
 fi
 
 if [ -s $FFILENAME ] ; then


### PR DESCRIPTION
This patch contains changes needed to be able to use Ironic Stein.

It has dependencies from other patches in other related repos
and they should all be merged at the same time, following the order below,
to guarantee a correct behavior.

Full patch set:
https://github.com/openshift-metal3/dev-scripts/pull/680
https://github.com/metal3-io/ironic-image/pull/79
https://github.com/metal3-io/ironic-inspector-image/pull/30
https://github.com/metal3-io/ironic-ipa-downloader/pull/3
