### PR TITLE
correct path for ipa image

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -2,7 +2,7 @@
 #CACHEURL=http://172.22.0.1/images
 
 # Which image should we use
-SNAP=${1:-current-tripleo-rdo}
+SNAP=${1:-current-tripleo}
 
 FILENAME=ironic-python-agent
 FILENAME_EXT=.tar


### PR DESCRIPTION
in train the path for the image is under current-tripleo and not current-tripleo-rdo