### PR TITLE
Enable the use of a proxy to download images

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -xe
 #CACHEURL=http://172.22.0.1/images
 
+# Check and set http(s)_proxy. Required for cURL to use a proxy
+export http_proxy=${http_proxy:-$HTTP_PROXY}
+export https_proxy=${https_proxy:-$HTTPS_PROXY}
+
 # Which image should we use
 SNAP=${1:-current-tripleo}
 IPA_BASEURI=${IPA_BASEURI:-https://images.rdoproject.org/train/rdo_trunk/$SNAP/}


### PR DESCRIPTION
Even though HTTP(S)_PROXY variable(s) is exposed in the container, curl requires the use of (lowercase) http(s)_proxy variables to function properly. This patch will enable curl to download images via a proxy.