### PR TITLE
Do not query for file headers on disconnected install

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -29,7 +29,7 @@ fi
 if [ -e $FFILENAME.headers ] ; then
     ETAG=$(awk '/ETag:/ {print $2}' $FFILENAME.headers | tr -d "\r")
     cd $TMPDIR
-    curl -g --verbose --dump-header $FFILENAME.headers -O $IPA_BASEURI/$FFILENAME --header "If-None-Match: $ETAG"
+    curl -g --verbose --dump-header $FFILENAME.headers -O $IPA_BASEURI/$FFILENAME --header "If-None-Match: $ETAG" || cp /shared/html/images/$FFILENAME.headers .
     # curl didn't download anything because we have the ETag already
     # but we don't have it in the images directory
     # Its in the cache, go get it


### PR DESCRIPTION
Even if we have the image cached locally, we try to do
a query for the latest headers of the file. On a disconnected
install this is causing a failure, so in that case we should
not error and take the already present headers.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>