### PR TITLE
move maelk to emeritus_reviewers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,8 @@ approvers:
 
 reviewers:
  - iurygregory
- - maelk
  - stbenjam
  - zaneb
+
+emeritus_reviewers:
+ - maelk


### PR DESCRIPTION
Maël's focus has shifted from this project to other tasks thus the
OWNERS list has to be modified accordingly.