### PR TITLE
change baseimage to newer centos 8 stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/centos:centos8
+FROM quay.io/centos/centos:stream8
 
 RUN dnf update -y && \
     dnf clean all && \


### PR DESCRIPTION
Centos 8 is deprecated and the metal3 project uses
Centos 8 stream baseimages everywhere anyways.

Additionally at the time of creating this commit Centos 8 based
container image bulding is broken because of
some dnf/yum repository problems.