### PR TITLE
Promote Iury to approvers, remove Stephen

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,11 +6,11 @@ approvers:
  - dtantsur
  - elfosardo
  - hardys
+ - iurygregory
 
 reviewers:
- - iurygregory
- - stbenjam
  - zaneb
 
 emeritus_reviewers:
  - maelk
+ - stbenjam


### PR DESCRIPTION
Iury is the Ironic PTL (project team lead) and has been consistently
reviewing ironic-image changes in his reviewer role.

Stephen has moved to another role.
