### PR TITLE
get-resources: shellcheck fixes + configuration options

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -1,59 +1,71 @@
-#!/bin/bash -xe
+#!/bin/bash
 #CACHEURL=http://172.22.0.1/images
 
+set -eux
+
 # Check and set http(s)_proxy. Required for cURL to use a proxy
-export http_proxy=${http_proxy:-$HTTP_PROXY}
-export https_proxy=${https_proxy:-$HTTPS_PROXY}
-export no_proxy=${no_proxy:-$NO_PROXY}
+export http_proxy="${http_proxy:-${HTTP_PROXY:-}}"
+export https_proxy="${https_proxy:-${HTTPS_PROXY:-}}"
+export no_proxy="${no_proxy:-${NO_PROXY:-}}"
+
+# configurable variables
+SHARED_DIR="${SHARED_DIR:-/shared}"
+CURL_OUTPUT=""
+if [ "${CURL_VERBOSE:-}" = true ]; then
+    CURL_OUTPUT="--verbose"
+fi
 
 # Which image should we use
-SNAP=${1:-current-tripleo}
-IPA_BASEURI=${IPA_BASEURI:-https://images.rdoproject.org/centos9/master/rdo_trunk/$SNAP/}
+SNAP="${1:-current-tripleo}"
+IPA_BASEURI="${IPA_BASEURI:-https://images.rdoproject.org/centos9/master/rdo_trunk/${SNAP}}"
 
-FILENAME=ironic-python-agent
-FILENAME_EXT=.tar
-FFILENAME=$FILENAME$FILENAME_EXT
+FILENAME="ironic-python-agent"
+FILENAME_EXT=".tar"
+FFILENAME="${FILENAME}${FILENAME_EXT}"
 
-mkdir -p /shared/html/images /shared/tmp
-cd /shared/html/images
+mkdir -p "${SHARED_DIR}"/html/images "${SHARED_DIR}"/tmp
+cd "${SHARED_DIR}"/html/images
 
-TMPDIR=$(mktemp -d -p /shared/tmp)
+TMPDIR="$(mktemp -d -p "${SHARED_DIR}"/tmp)"
 
 # If we have a CACHEURL and nothing has yet been downloaded
 # get header info from the cache
-ls -l
-if [ -n "$CACHEURL" -a ! -e $FFILENAME.headers ] ; then
-    curl -g --verbose --fail -O "$CACHEURL/$FFILENAME.headers" || true
+
+if [ -n "${CACHEURL:-}" ] && [ ! -e "${FFILENAME}.headers" ]; then
+    curl -g ${CURL_OUTPUT} --fail -O "${CACHEURL}/${FFILENAME}.headers" || true
 fi
 
 # Download the most recent version of IPA
-if [ -e $FFILENAME.headers ] ; then
-    ETAG=$(awk '/ETag:/ {print $2}' $FFILENAME.headers | tr -d "\r")
-    cd $TMPDIR
-    curl -g --verbose --dump-header $FFILENAME.headers -O $IPA_BASEURI/$FFILENAME --header "If-None-Match: $ETAG" || cp /shared/html/images/$FFILENAME.headers .
+if [ -r "${FFILENAME}.headers" ] ; then
+    ETAG="$(awk '/ETag:/ {print $2}' ${FFILENAME}.headers | tr -d "\r")"
+    cd "${TMPDIR}"
+    curl -g ${CURL_OUTPUT} --dump-header "${FFILENAME}.headers" \
+        -O "${IPA_BASEURI}/${FFILENAME}" \
+        --header "If-None-Match: ${ETAG}" || cp "${SHARED_DIR}/html/images/${FFILENAME}.headers" .
+
     # curl didn't download anything because we have the ETag already
     # but we don't have it in the images directory
     # Its in the cache, go get it
-    ETAG=$(awk '/ETag:/ {print $2}' $FFILENAME.headers | tr -d "\"\r")
-    if [ ! -s $FFILENAME -a ! -e /shared/html/images/$FILENAME-$ETAG/$FFILENAME ] ; then
-        mv /shared/html/images/$FFILENAME.headers .
-        curl -g --verbose -O "$CACHEURL/$FILENAME-$ETAG/$FFILENAME"
+    ETAG="$(awk '/ETag:/ {print $2}' ${FFILENAME}.headers | tr -d "\"\r")"
+    if [ ! -s ${FFILENAME} ] && [ ! -e "${SHARED_DIR}/html/images/${FILENAME}-${ETAG}/${FFILENAME}" ]; then
+        mv "${SHARED_DIR}/html/images/${FFILENAME}.headers" .
+        curl -g ${CURL_OUTPUT} -O "${CACHEURL}/${FILENAME}-${ETAG}/${FFILENAME}"
     fi
 else
-    cd $TMPDIR
-    curl -g --verbose --dump-header $FFILENAME.headers -O $IPA_BASEURI/$FFILENAME
+    cd "${TMPDIR}"
+    curl -g ${CURL_OUTPUT} --dump-header "${FFILENAME}.headers" -O "${IPA_BASEURI}/${FFILENAME}"
 fi
 
-if [ -s $FFILENAME ] ; then
-    tar -xf $FFILENAME
+if [ -s "${FFILENAME}" ]; then
+    tar -xf "${FFILENAME}"
 
-    ETAG=$(awk '/ETag:/ {print $2}' $FFILENAME.headers | tr -d "\"\r")
+    ETAG="$(awk '/ETag:/ {print $2}' "${FFILENAME}.headers" | tr -d "\"\r")"
     cd -
-    chmod 755 $TMPDIR
-    mv $TMPDIR $FILENAME-$ETAG
-    ln -sf $FILENAME-$ETAG/$FFILENAME.headers $FFILENAME.headers
-    ln -sf $FILENAME-$ETAG/$FILENAME.initramfs $FILENAME.initramfs
-    ln -sf $FILENAME-$ETAG/$FILENAME.kernel $FILENAME.kernel
+    chmod 755 "${TMPDIR}"
+    mv "${TMPDIR}" "${FILENAME}-${ETAG}"
+    ln -sf "${FILENAME}-${ETAG}/${FFILENAME}.headers" "${FFILENAME}.headers"
+    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.initramfs" "${FILENAME}.initramfs"
+    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.kernel" "${FILENAME}.kernel"
 else
-    rm -rf $TMPDIR
+    rm -rf "${TMPDIR}"
 fi

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
+
+if [ -z "${IS_CONTAINER:-}" ]; then
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" \
+    -type f -name '*.sh' -exec shellcheck -s bash {} \+
+else
+  "${CONTAINER_RUNTIME}" run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    --workdir /workdir \
+    docker.io/koalaman/shellcheck-alpine:stable \
+    /workdir/hack/shellcheck.sh "${@}"
+fi


### PR DESCRIPTION
Do some maintenance work on get-resources.sh:

- Fix shellcheck issues in get-resource.sh.
- Add shellcheck validator in hack/. At first, for local static checks and later on to be verified by automation.
- Add SHARED_DIR env for configuring the shared directory to be able to run the script outside containers. Default is the old /shared.
- Add CURL_VERBOSE env for configuring curl verbosity, as --verbose by default keeps spamming TLS data. Any non-empty CURL_VERBOSE sets --verbose for curl