### PR TITLE
shellcheck: pin to 0.9.0

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -2,18 +2,18 @@
 
 set -eux
 
+IS_CONTAINER=${IS_CONTAINER:-false}
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
-if [ -z "${IS_CONTAINER:-}" ]; then
+if [ "${IS_CONTAINER}" != "false" ]; then
   TOP_DIR="${1:-.}"
-  find "${TOP_DIR}" \
-    -type f -name '*.sh' -exec shellcheck -s bash {} \+
+  find "${TOP_DIR}" -name '*.sh' -exec shellcheck -s bash {} \+
 else
   "${CONTAINER_RUNTIME}" run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
     --workdir /workdir \
-    docker.io/koalaman/shellcheck-alpine:stable \
+    docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7 \
     /workdir/hack/shellcheck.sh "${@}"
-fi
+fi;


### PR DESCRIPTION
Pin shellcheck to v0.9.0 with digest.

Also, make the logic work like all the other shellcheck scripts in Metal3.