### PR TITLE
pin centos:stream9 to a sha digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/centos/centos:stream9
+ARG BASE_IMAGE=quay.io/centos/centos:stream9@sha256:06cfbf69d99f47f45f327d18fec086509ca0c74afdb178fb8c5bc45184454cc0
+
+FROM $BASE_IMAGE
 
 RUN dnf upgrade -y && \
     dnf clean all && \


### PR DESCRIPTION
Add support to BASE_IMAGE and pin the image to a sha.