### PR TITLE
revert centos:stream9 pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/centos/centos:stream9@sha256:06cfbf69d99f47f45f327d18fec086509ca0c74afdb178fb8c5bc45184454cc0
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
quay.io cleans up old images, so the pinned image no longer exists. We cannot pin images that are originating from quay.io.
Revert the digest part of https://github.com/metal3-io/ironic-ipa-downloader/pull/41