### PR TITLE
Use upstream IPA ramdisks instead of current-tripleo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This repository contains scripts to download the Ironic-Python-Agent (IPA)
 ramdisk images to a shared volume. By default, we pull IPA images from
-[RDO trunk](https://images.rdoproject.org/centos9/master/rdo_trunk) registry.
-However, it is possible to override this URI to a custom URI by exporting
-`IPA_BASEURI` environment variable.
+[Ironic upstream](https://tarballs.opendev.org/openstack/ironic-python-agent/dib)
+archive where an image is built on every commit to the *master* git branch.
+
+It is possible to override this URI to a custom URI by exporting the
+`IPA_BASEURI` environment variable. You can also use a *stable branch* by
+exporting `IPA_BRANCH` variable.
 
 ## How to build custom IPA ramdisk image
 
@@ -34,9 +37,8 @@ check the disk-image builder
 
    ```shell
    ironic-python-agent-builder --output ironic-python-agent \
-     --release 8-stream centos \
-     --element='dynamic-login' \
-     --element='extra-hardware' --verbose
+     --release 9-stream centos \
+     --element='dynamic-login'
    ```
 
    - `--release` - Distribution release to use.
@@ -44,9 +46,6 @@ check the disk-image builder
      available [elements](https://docs.openstack.org/diskimage-builder/latest/).
    - `output` - Output base file name
    - `centos` - Base distribution.
-   - [extra-hardware](https://docs.openstack.org/ironic-python-agentbuilder/latest/admin/dib.html#ironic-python-agent-ipa-extra-hardware)
-     DIB element is required to install required utilities for improving
-     introspection.
    - [dynamic-login](https://docs.openstack.org/diskimage-builder/latest/elements/dynamic-login/README.html)
      DIB element allows to inject SSH key in the image.
 

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -37,7 +37,7 @@ fi
 
 # Download the most recent version of IPA
 if [ -r "${FFILENAME}.headers" ] ; then
-    ETAG="$(awk '/ETag:/ {print $2}' ${FFILENAME}.headers | tr -d "\r")"
+    ETAG="$(awk '/ETag:/ {print $2}' "${FFILENAME}.headers" | tr -d "\r")"
     cd "${TMPDIR}"
     curl -g ${CURL_OUTPUT} --dump-header "${FFILENAME}.headers" \
         -O "${IPA_BASEURI}/${FFILENAME}" \
@@ -46,8 +46,8 @@ if [ -r "${FFILENAME}.headers" ] ; then
     # curl didn't download anything because we have the ETag already
     # but we don't have it in the images directory
     # Its in the cache, go get it
-    ETAG="$(awk '/ETag:/ {print $2}' ${FFILENAME}.headers | tr -d "\"\r")"
-    if [ ! -s ${FFILENAME} ] && [ ! -e "${SHARED_DIR}/html/images/${FILENAME}-${ETAG}/${FFILENAME}" ]; then
+    ETAG="$(awk '/ETag:/ {print $2}' "${FFILENAME}.headers" | tr -d "\"\r")"
+    if [ ! -s "${FFILENAME}" ] && [ ! -e "${SHARED_DIR}/html/images/${FILENAME}-${ETAG}/${FFILENAME}" ]; then
         mv "${SHARED_DIR}/html/images/${FFILENAME}.headers" .
         curl -g ${CURL_OUTPUT} -O "${CACHEURL}/${FILENAME}-${ETAG}/${FFILENAME}"
     fi

--- a/get-resource.sh
+++ b/get-resource.sh
@@ -16,12 +16,14 @@ if [ "${CURL_VERBOSE:-}" = true ]; then
 fi
 
 # Which image should we use
-SNAP="${1:-current-tripleo}"
-IPA_BASEURI="${IPA_BASEURI:-https://images.rdoproject.org/centos9/master/rdo_trunk/${SNAP}}"
+IPA_BASEURI="${IPA_BASEURI:-https://tarballs.opendev.org/openstack/ironic-python-agent/dib}"
+IPA_BRANCH="$(echo "${IPA_BRANCH:-master}" | tr / -)"
+IPA_FLAVOR="${IPA_FLAVOR:-centos9}"
 
-FILENAME="ironic-python-agent"
-FILENAME_EXT=".tar"
+FILENAME="ipa-${IPA_FLAVOR}-${IPA_BRANCH}"
+FILENAME_EXT=".tar.gz"
 FFILENAME="${FILENAME}${FILENAME_EXT}"
+DESTNAME="ironic-python-agent"
 
 mkdir -p "${SHARED_DIR}"/html/images "${SHARED_DIR}"/tmp
 cd "${SHARED_DIR}"/html/images
@@ -36,8 +38,8 @@ if [ -n "${CACHEURL:-}" ] && [ ! -e "${FFILENAME}.headers" ]; then
 fi
 
 # Download the most recent version of IPA
-if [ -r "${FFILENAME}.headers" ] ; then
-    ETAG="$(awk '/ETag:/ {print $2}' "${FFILENAME}.headers" | tr -d "\r")"
+if [ -r "${DESTNAME}.headers" ] ; then
+    ETAG="$(awk '/ETag:/ {print $2}' "${DESTNAME}.headers" | tr -d "\r")"
     cd "${TMPDIR}"
     curl -g ${CURL_OUTPUT} --dump-header "${FFILENAME}.headers" \
         -O "${IPA_BASEURI}/${FFILENAME}" \
@@ -57,15 +59,15 @@ else
 fi
 
 if [ -s "${FFILENAME}" ]; then
-    tar -xf "${FFILENAME}"
+    tar -xaf "${FFILENAME}"
 
     ETAG="$(awk '/ETag:/ {print $2}' "${FFILENAME}.headers" | tr -d "\"\r")"
     cd -
     chmod 755 "${TMPDIR}"
     mv "${TMPDIR}" "${FILENAME}-${ETAG}"
-    ln -sf "${FILENAME}-${ETAG}/${FFILENAME}.headers" "${FFILENAME}.headers"
-    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.initramfs" "${FILENAME}.initramfs"
-    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.kernel" "${FILENAME}.kernel"
+    ln -sf "${FILENAME}-${ETAG}/${FFILENAME}.headers" "${DESTNAME}.headers"
+    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.initramfs" "${DESTNAME}.initramfs"
+    ln -sf "${FILENAME}-${ETAG}/${FILENAME}.kernel" "${DESTNAME}.kernel"
 else
     rm -rf "${TMPDIR}"
 fi


### PR DESCRIPTION
The TripleO project has been sunset, and the images have not been
updated since April. Use the images provided by Ironic.
