### PR TITLE
switch markdownlint container to markdownlint-cli2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+# Reference: https://github.com/DavidAnson/markdownlint-cli2#markdownlint-cli2yaml
+
+config:
+  ul-indent:
+    # Kramdown wanted us to have 3 earlier, tho this CLI recommends 2 or 4
+    indent: 3
+
+# Don't autofix anything, we're linting here
+fix: false

--- a/hack/markdownlint.sh
+++ b/hack/markdownlint.sh
@@ -1,19 +1,20 @@
 #!/bin/sh
+# markdownlint-cli2 has config file(s) named .markdownlint-cli2.yaml in the repo
 
 set -eux
 
 IS_CONTAINER="${IS_CONTAINER:-false}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-podman}"
 
+# all md files, but ignore .github
 if [ "${IS_CONTAINER}" != "false" ]; then
-    TOP_DIR="${1:-.}"
-    find "${TOP_DIR}" -type d \( -path ./vendor -o -path ./.github \) -prune -o -name '*.md' -exec mdl --style all --warnings {} \+
+    markdownlint-cli2 "**/*.md" "#.github"
 else
     "${CONTAINER_RUNTIME}" run --rm \
         --env IS_CONTAINER=TRUE \
         --volume "${PWD}:/workdir:ro,z" \
         --entrypoint sh \
         --workdir /workdir \
-        docker.io/pipelinecomponents/markdownlint:0.13.0@sha256:9c0cdfb64fd3f1d3bdc5181629b39c2e43b6a52fc9fdc146611e1860845bbae0 \
+        docker.io/pipelinecomponents/markdownlint-cli2:0.9.0@sha256:71370df6c967bae548b0bfd0ae313ddf44bfad87da76f88180eff55c6264098c \
         /workdir/hack/markdownlint.sh "$@"
 fi


### PR DESCRIPTION
Switch markdownlint container to markdownlint-cli2. This CLI version supports the enable/disable rules in markdown files and allows us to ignore issues locally, not just globally.

- project-infra PR https://github.com/metal3-io/project-infra/pull/619 needs to merge for markdownlint here to pass
