### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,18 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - derekhiggins
- - dtantsur
- - elfosardo
- - iurygregory
+- ironic-ipa-downloader-maintainers
 
 reviewers:
- - zaneb
+- ironic-ipa-downloader-maintainers
+- ironic-ipa-downloader-reviewers
 
 emeritus_approvers:
- - bfournie
- - hardys
+- bfournie
+- hardys
 
 emeritus_reviewers:
- - maelk
- - stbenjam
+- maelk
+- stbenjam

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ironic-ipa-downloader-maintainers:
+  - derekhiggins
+  - dtantsur
+  - elfosardo
+  - iurygregory
+
+  ironic-ipa-downloader-reviewers:
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.