### PR TITLE
Fix script to handle IPA images of branches like 2024.1

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -27,7 +27,7 @@ IPA_BRANCH="$(echo "${IPA_BRANCH:-master}" | tr / -)"
 IPA_FLAVOR="${IPA_FLAVOR:-centos9}"
 
 FILENAME="${FILENAME:-ipa-${IPA_FLAVOR}-${IPA_BRANCH}.tar.gz}"
-FILENAME_NO_EXT="${FILENAME%%.*}"
+FILENAME_NO_EXT="${FILENAME%.*.*}"
 DESTNAME="ironic-python-agent"
 
 mkdir -p "${SHARED_DIR}"/html/images "${SHARED_DIR}"/tmp


### PR DESCRIPTION
Now it creates dangling symlinks for those images as it strips '.1' from the filename.

ln -sf ipa-centos9-stable-2024.1.tar.gz-207f84b2-62d8b4022f200/ipa-centos9-stable-2024.initramfs ironic-python-agent.initramfs