### PR TITLE
Improve file extension parsing with tar

### DIFF
--- a/get-resource.sh
+++ b/get-resource.sh
@@ -21,13 +21,30 @@ curl_with_flags() {
     curl "$@"
 }
 
+EXTENSIONS=${EXTENSIONS:-".tar.gz .tar.gz.sha256"}
+
+get_filename_without_extension() {
+	local filename=$1
+	local filename_without_extension="${filename%.*.*}"
+
+	for ex in ${EXTENSIONS}; do
+		bname=$(basename "${filename}" "${ex}")
+		if [ "${filename:${#bname}}" = "${ex}" ]; then
+			filename_without_extension="${bname}"
+			break
+		fi
+	done
+
+	echo -n "${filename_without_extension}"
+}
+
 # Which image should we use
 IPA_BASEURI="${IPA_BASEURI:-https://tarballs.opendev.org/openstack/ironic-python-agent/dib}"
 IPA_BRANCH="$(echo "${IPA_BRANCH:-master}" | tr / -)"
 IPA_FLAVOR="${IPA_FLAVOR:-centos9}"
 
 FILENAME="${IPA_FILENAME:-ipa-${IPA_FLAVOR}-${IPA_BRANCH}.tar.gz}"
-FILENAME_NO_EXT="${FILENAME%.*.*}"
+FILENAME_NO_EXT=$(get_filename_without_extension "${FILENAME}")
 DESTNAME="ironic-python-agent"
 
 mkdir -p "${SHARED_DIR}"/html/images "${SHARED_DIR}"/tmp


### PR DESCRIPTION
Fixes #62 

Added a list of compression extensions supported by tar. The image file extensions are primarily checked against this list, and if no match is found then it falls back to regex parsing.