### PR TITLE
:sparkles: enable container signing

### DIFF
--- a/.github/workflows/build-images-action.yml
+++ b/.github/workflows/build-images-action.yml
@@ -22,6 +22,7 @@ jobs:
       image-name: 'ironic-ipa-downloader'
       pushImage: true
       generate-sbom: true
+      sign-image: true
     secrets:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
This commit enables container signing for all images build from this repository via build-images-action.yml and release.yml, both reusing container-image-build.yml from project-infra.

All container images will be built with keyless signing, utilizing short-lived Github Actions OIDC tokens (id-token: write) and the certificates and transparency logs are utilizing Sigstore's public Fulcio and Rekor services.