### PR TITLE
🌱 Set cooldown days to 3 for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
   - dependency-name: "*"
     update-types: ["version-update:semver-major"]
   cooldown:
-    default-days: 7
+    default-days: 3
   commit-message:
     prefix: ":seedling:"
   labels:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,9 +28,12 @@ jobs:
     - name: Run zizmor (SARIF)
       if: github.event_name == 'push'
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+      with:
+        config: .zizmor.yml
     # Block PRs with findings
     - name: Run zizmor (PR check)
       if: github.event_name == 'pull_request'
       uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
       with:
         advanced-security: false
+        config: .zizmor.yml

--- a/.zizmor.yml
+++ b/.zizmor.yml
@@ -1,0 +1,9 @@
+# zizmor configuration file
+# This file controls zizmor automation rules such as Dependabot throttling.
+# See zizmor documentation for more details:
+# https://docs.zizmor.sh/
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3


### PR DESCRIPTION
Changed the dependabot cooldown from 7 days to 3 days. This adds a proper `.zizmor.yml` config at the repo root. The workflow at `.github/workflows/zizmor.yml` picks it up via the `config:` input.